### PR TITLE
Ignore issue when coming from the same class

### DIFF
--- a/access-modifier-annotation/src/main/java/org/kohsuke/accmod/impl/RestrictedElement.java
+++ b/access-modifier-annotation/src/main/java/org/kohsuke/accmod/impl/RestrictedElement.java
@@ -38,5 +38,13 @@ public interface RestrictedElement {
      */
     boolean isInTheInspectedModule();
 
+    /**
+     * Returns true if the given {@link Location} is actually in <code>this</code>.
+     *
+     * @param location the location to be tested.
+     * @return true if the given {@link Location} is actually in <code>this</code>.
+     */
+    boolean isSameClass(Location location);
+
     String toString();
 }

--- a/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/DoNotUse.java
+++ b/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/DoNotUse.java
@@ -35,26 +35,44 @@ import org.kohsuke.accmod.impl.RestrictedElement;
  */
 public class DoNotUse extends AccessRestriction {
     public void written(Location loc, RestrictedElement target, ErrorListener errorListener) {
+        if (target.isSameClass(loc)) {
+            return;
+        }
         error(loc,target,errorListener);
     }
 
     public void usedAsSuperType(Location loc, RestrictedElement target, ErrorListener errorListener) {
+        if (target.isSameClass(loc)) {
+            return;
+        }
         error(loc,target,errorListener);
     }
 
     public void usedAsInterface(Location loc, RestrictedElement target, ErrorListener errorListener) {
+        if (target.isSameClass(loc)) {
+            return;
+        }
         error(loc,target,errorListener);
     }
 
     public void instantiated(Location loc, RestrictedElement target, ErrorListener errorListener) {
+        if (target.isSameClass(loc)) {
+            return;
+        }
         error(loc,target,errorListener);
     }
 
     public void invoked(Location loc, RestrictedElement target, ErrorListener errorListener) {
+        if (target.isSameClass(loc)) {
+            return;
+        }
         error(loc,target,errorListener);
     }
 
     public void read(Location loc, RestrictedElement target, ErrorListener errorListener) {
+        if (target.isSameClass(loc)) {
+            return;
+        }
         error(loc,target,errorListener);
     }
 

--- a/access-modifier-checker/pom.xml
+++ b/access-modifier-checker/pom.xml
@@ -14,7 +14,19 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.2.15</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.4.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -176,13 +176,7 @@ public class Checker {
                      */
                     private AnnotationVisitor onAnnotationFor(final String keyName, String desc) {
                         if (RESTRICTED_DESCRIPTOR.equals(desc)) {
-                            RestrictedElement target = new RestrictedElement() {
-                                public boolean isInTheInspectedModule() {
-                                    return isInTheInspectedModule;
-                                }
-
-                                public String toString() { return keyName; }
-                            };
+                            RestrictedElement target = new RestrictedElementImpl(isInTheInspectedModule, keyName);
                             return new Parser(target) {
                                 @Override
                                 public void visitEnd() {

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/RestrictedElementImpl.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/RestrictedElementImpl.java
@@ -1,0 +1,39 @@
+package org.kohsuke.accmod.impl;
+
+public class RestrictedElementImpl implements RestrictedElement {
+    private final boolean isInTheInspectedModule;
+    private final String keyName;
+
+    public RestrictedElementImpl(boolean isInTheInspectedModule, String keyName) {
+        this.isInTheInspectedModule = isInTheInspectedModule;
+        this.keyName = keyName;
+    }
+
+    public boolean isInTheInspectedModule() {
+        return isInTheInspectedModule;
+    }
+
+    @Override
+    public boolean isSameClass(Location location) {
+        String locationClassName = location.getClassName();
+        if (locationClassName.contains("$")) {
+            locationClassName = locationClassName.split("\\$")[0];
+        }
+        if(keyToClassName(keyName).equals(locationClassName)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static String keyToClassName(String key) {
+        if (key.contains(".")) {
+            key = key.split("\\.")[0];
+        }
+        return key.replace('/', '.');
+    }
+
+
+    public String toString() {
+        return keyName;
+    }
+}

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Restrictions.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Restrictions.java
@@ -81,6 +81,12 @@ public class Restrictions extends ArrayList<AccessRestriction> {
 
     public static final Restrictions NONE = new Restrictions(new RestrictedElement() {
         public boolean isInTheInspectedModule() { return false; }
+
+        @Override
+        public boolean isSameClass(Location location) {
+            return false;
+        }
+
         public String toString() { return "NONE"; }
     });
 

--- a/access-modifier-checker/src/test/java/org.kohsuke.accmod.impl/RestrictedElementImplTest.java
+++ b/access-modifier-checker/src/test/java/org.kohsuke.accmod.impl/RestrictedElementImplTest.java
@@ -1,0 +1,32 @@
+package org.kohsuke.accmod.impl;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RestrictedElementImplTest {
+
+    @Test
+    public void basic() throws Exception {
+
+        assertThat(new RestrictedElementImpl(false, "hudson/util/TimeUnit2")
+                           .isSameClass(createLocation("hudson.util.TimeUnit2$4"))).isTrue();
+
+        assertThat(new RestrictedElementImpl(false, "hudson/util/TimeUnit2.someMethod();")
+                           .isSameClass(createLocation("hudson.util.TimeUnit2$4"))).isTrue();
+
+        assertThat(new RestrictedElementImpl(false, "hudson/util/XStream2.addCriticalField(Ljava/lang/Class;Ljava/lang/String;)V")
+                           .isSameClass(createLocation("jenkins.model.Jenkins"))).isFalse();
+
+        assertThat(new RestrictedElementImpl(false, "jenkins/model/Jenkins.expandVariablesForDirectory(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String; ")
+                           .isSameClass(createLocation("jenkins.model.Jenkins$DescriptorImpl"))).isTrue();
+    }
+
+    private Location createLocation(String value) {
+        Location location = mock(Location.class);
+        when(location.getClassName()).thenReturn(value);
+        return location;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
   <packaging>pom</packaging>
   <description>Extensible application-specific access modifiers for Java</description>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <modules>
     <module>access-modifier-annotation</module>
     <module>access-modifier-checker</module>


### PR DESCRIPTION
Trying to fix https://github.com/jenkinsci/jenkins/pull/2892 I got blocked because `DoNotUse` would fail apparently on `TimeUnit2` enum instances. This fixes this behaviour and ignores issues when an usage is from the same class. (for instance, it's OK for a class marked DoNotUse to leave it as is, that it calls itself)