### PR TITLE
The checker was failing to apply DoNotUse/NoExternalUse to nested members

### DIFF
--- a/access-modifier-annotation/src/main/java/org/kohsuke/accmod/AccessRestriction.java
+++ b/access-modifier-annotation/src/main/java/org/kohsuke/accmod/AccessRestriction.java
@@ -85,6 +85,13 @@ public abstract class AccessRestriction {
      */
     public abstract void written(Location loc, RestrictedElement target, ErrorListener errorListener);
 
+    /**
+     * Whether this access restriction, if applied to a type, should also be considered to apply implicitly to all transitively nested members.
+     * @return by default, false
+     */
+    public boolean appliesToNested() {
+        return false;
+    }
 
     /**
      * {@link AccessRestriction} that imposes no restriction.

--- a/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/DoNotUse.java
+++ b/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/DoNotUse.java
@@ -61,4 +61,10 @@ public class DoNotUse extends AccessRestriction {
     public void error(Location loc, RestrictedElement target, ErrorListener errorListener) {
         errorListener.onError(null,loc,target+" must not be used");
     }
+
+    @Override
+    public boolean appliesToNested() {
+        return true;
+    }
+
 }

--- a/access-modifier-checker/src/it/method-inside-type/api/pom.xml
+++ b/access-modifier-checker/src/it/method-inside-type/api/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>method-inside-type</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>api</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/access-modifier-checker/src/it/method-inside-type/api/src/main/java/api/Api.java
+++ b/access-modifier-checker/src/it/method-inside-type/api/src/main/java/api/Api.java
@@ -1,0 +1,17 @@
+package api;
+
+import api.impl.NotApi;
+
+public class Api {
+
+    public Api() {}
+
+    public static void actuallyPublic() {
+        NotApi.notReallyPublic(); // OK
+        new NotApi().notReallyPublicF.hashCode(); // OK
+        NotApi.AlsoNotApi.alsoNotReallyPublic(); // OK
+    }
+
+    public final Object actuallyPublicF = new Object();
+
+}

--- a/access-modifier-checker/src/it/method-inside-type/api/src/main/java/api/impl/NotApi.java
+++ b/access-modifier-checker/src/it/method-inside-type/api/src/main/java/api/impl/NotApi.java
@@ -1,0 +1,27 @@
+package api.impl;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class NotApi {
+
+    public NotApi() {}
+
+    public static void notReallyPublic() {}
+
+    public final Object notReallyPublicF = new Object();
+
+    static {
+        notReallyPublic(); // OK
+        new NotApi().notReallyPublicF.hashCode(); // OK
+        AlsoNotApi.alsoNotReallyPublic(); // OK
+    }
+
+    public static final class AlsoNotApi {
+
+        public static void alsoNotReallyPublic() {}
+
+    }
+
+}

--- a/access-modifier-checker/src/it/method-inside-type/caller/pom.xml
+++ b/access-modifier-checker/src/it/method-inside-type/caller/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>method-inside-type</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>caller</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.kohsuke</groupId>
+                <artifactId>access-modifier-checker</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+           </plugin>
+        </plugins>
+    </build>
+</project>

--- a/access-modifier-checker/src/it/method-inside-type/caller/src/main/java/caller/Caller.java
+++ b/access-modifier-checker/src/it/method-inside-type/caller/src/main/java/caller/Caller.java
@@ -1,0 +1,17 @@
+package caller;
+
+import api.Api;
+import api.impl.NotApi;
+
+public class Caller {
+
+    public Caller() {
+        Api.actuallyPublic(); // OK
+        new Api().actuallyPublicF.hashCode(); // OK
+        NotApi.notReallyPublic(); // illegal
+        NotApi na = new NotApi(); // illegal
+        na.notReallyPublicF.hashCode(); // illegal
+        NotApi.AlsoNotApi.alsoNotReallyPublic(); // illegal
+    }
+
+}

--- a/access-modifier-checker/src/it/method-inside-type/invoker.properties
+++ b/access-modifier-checker/src/it/method-inside-type/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean package
+invoker.buildResult = failure

--- a/access-modifier-checker/src/it/method-inside-type/pom.xml
+++ b/access-modifier-checker/src/it/method-inside-type/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>method-inside-type</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+    <modules>
+        <module>api</module>
+        <module>caller</module>
+    </modules>
+</project>

--- a/access-modifier-checker/src/it/method-inside-type/postbuild.groovy
+++ b/access-modifier-checker/src/it/method-inside-type/postbuild.groovy
@@ -1,0 +1,5 @@
+def text = new File(basedir, 'build.log').text
+assert text.contains('[ERROR] caller/Caller:11 api/impl/NotApi must not be used')
+assert text.contains('[ERROR] caller/Caller:12 api/impl/NotApi must not be used')
+assert text.contains('[ERROR] caller/Caller:13 api/impl/NotApi must not be used')
+assert text.contains('[ERROR] caller/Caller:14 api/impl/NotApi must not be used')

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Restrictions.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Restrictions.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @author Kohsuke Kawaguchi
  */
 public class Restrictions extends ArrayList<AccessRestriction> {
-    private final RestrictedElement target;
+    final RestrictedElement target;
 
     public Restrictions(RestrictedElement target, Collection<? extends AccessRestriction> c) {
         super(c);
@@ -76,13 +76,6 @@ public class Restrictions extends ArrayList<AccessRestriction> {
         for (AccessRestriction ar : this)
             ar.written(location,target,errorListener);
     }
-
-
-
-    public static final Restrictions NONE = new Restrictions(new RestrictedElement() {
-        public boolean isInTheInspectedModule() { return false; }
-        public String toString() { return "NONE"; }
-    });
 
     abstract static class Parser extends AnnotationVisitor {
         private List<Type> restrictions = new ArrayList<Type>();


### PR DESCRIPTION
After #3 it seems the checker was still not doing its job. https://github.com/jenkinsci/support-core-plugin/pull/137 should not have been necessary, yet actually other plugins were able to call

```java
Helper.getActiveInstance()
```

without errors.

@reviewbybees esp. @dwnusbaum