### PR TITLE
Added skip and failOnError flags to mojo

### DIFF
--- a/access-modifier-checker/src/it/failOnError/api/pom.xml
+++ b/access-modifier-checker/src/it/failOnError/api/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>failOnError</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>api</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/access-modifier-checker/src/it/failOnError/api/src/main/java/api/Api.java
+++ b/access-modifier-checker/src/it/failOnError/api/src/main/java/api/Api.java
@@ -1,0 +1,15 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+public class Api {
+
+    @Restricted(NoExternalUse.class)
+    public static void notReallyPublic() {}
+
+    static {
+        notReallyPublic(); // OK
+    }
+
+}

--- a/access-modifier-checker/src/it/failOnError/caller/pom.xml
+++ b/access-modifier-checker/src/it/failOnError/caller/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>failOnError</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>caller</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <properties>
+        <access-modifier-checker.failOnError>false</access-modifier-checker.failOnError>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.kohsuke</groupId>
+                <artifactId>access-modifier-checker</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+           </plugin>
+        </plugins>
+    </build>
+</project>

--- a/access-modifier-checker/src/it/failOnError/caller/src/main/java/caller/Caller.java
+++ b/access-modifier-checker/src/it/failOnError/caller/src/main/java/caller/Caller.java
@@ -1,0 +1,11 @@
+package caller;
+
+import api.Api;
+
+public class Caller {
+
+    public Caller() {
+        Api.notReallyPublic(); // illegal
+    }
+
+}

--- a/access-modifier-checker/src/it/failOnError/invoker.properties
+++ b/access-modifier-checker/src/it/failOnError/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean package

--- a/access-modifier-checker/src/it/failOnError/pom.xml
+++ b/access-modifier-checker/src/it/failOnError/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>failOnError</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+    <modules>
+        <module>api</module>
+        <module>caller</module>
+    </modules>
+</project>

--- a/access-modifier-checker/src/it/failOnError/postbuild.groovy
+++ b/access-modifier-checker/src/it/failOnError/postbuild.groovy
@@ -1,0 +1,1 @@
+assert new File(basedir, 'build.log').text.contains('[WARNING] caller/Caller:8 api/Api.notReallyPublic()V must not be used')

--- a/access-modifier-checker/src/it/skip/api/pom.xml
+++ b/access-modifier-checker/src/it/skip/api/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>skip</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>api</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/access-modifier-checker/src/it/skip/api/src/main/java/api/Api.java
+++ b/access-modifier-checker/src/it/skip/api/src/main/java/api/Api.java
@@ -1,0 +1,15 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+public class Api {
+
+    @Restricted(NoExternalUse.class)
+    public static void notReallyPublic() {}
+
+    static {
+        notReallyPublic(); // OK
+    }
+
+}

--- a/access-modifier-checker/src/it/skip/caller/pom.xml
+++ b/access-modifier-checker/src/it/skip/caller/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>skip</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>caller</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.kohsuke</groupId>
+                <artifactId>access-modifier-checker</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+           </plugin>
+        </plugins>
+    </build>
+</project>

--- a/access-modifier-checker/src/it/skip/caller/src/main/java/caller/Caller.java
+++ b/access-modifier-checker/src/it/skip/caller/src/main/java/caller/Caller.java
@@ -1,0 +1,11 @@
+package caller;
+
+import api.Api;
+
+public class Caller {
+
+    public Caller() {
+        Api.notReallyPublic(); // illegal
+    }
+
+}

--- a/access-modifier-checker/src/it/skip/invoker.properties
+++ b/access-modifier-checker/src/it/skip/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean package

--- a/access-modifier-checker/src/it/skip/pom.xml
+++ b/access-modifier-checker/src/it/skip/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>skip</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+    <modules>
+        <module>api</module>
+        <module>caller</module>
+    </modules>
+</project>

--- a/access-modifier-checker/src/it/skip/postbuild.groovy
+++ b/access-modifier-checker/src/it/skip/postbuild.groovy
@@ -1,0 +1,1 @@
+assert new File(basedir, 'build.log').text.contains('[INFO] Skipping access modifier checks')


### PR DESCRIPTION
As suggested in #7, and in line with [`findbugs:check`](https://gleclaire.github.io/findbugs-maven-plugin/check-mojo.html) for example. Could be used when you intentionally are still using a restricted API for the moment, but what I have _really_ needed this for is `Jenkinsfile`: when you write

```groovy
buildPlugin(jenkinsVersions: [null, '2.107'])
```

and then somebody made some API

```java
/** @deprecated prefer {@link #whatever} */
@Deprecated
@Restricted(DoNotUse.class)
public void oldStyle() {}
```

which is an antipattern (simple deprecation suffices!), the build breaks and so we are unable to check actual compatibility of the plugin against some newer core, which is very irritating. If this is accepted and integrated into the parent, I would patch `buildPlugin.groovy` to add `-Daccess-modifier-checker.failOnError=false` to the `mvn` command when building against a nondefault Jenkins version.

@reviewbybees esp. @dwnusbaum & @kohsuke