### PR TITLE
Ignore synthetic code

### DIFF
--- a/access-modifier-checker/src/it/synthetics/invoker.properties
+++ b/access-modifier-checker/src/it/synthetics/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean package

--- a/access-modifier-checker/src/it/synthetics/pom.xml
+++ b/access-modifier-checker/src/it/synthetics/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>synthetics-method-impl</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.kohsuke</groupId>
+                <artifactId>access-modifier-checker</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+           </plugin>
+        </plugins>
+    </build>
+</project>

--- a/access-modifier-checker/src/it/synthetics/src/main/java/Base.java
+++ b/access-modifier-checker/src/it/synthetics/src/main/java/Base.java
@@ -1,0 +1,3 @@
+abstract public class Base<T> {
+    abstract T doStuff();
+}

--- a/access-modifier-checker/src/it/synthetics/src/main/java/Subtype.java
+++ b/access-modifier-checker/src/it/synthetics/src/main/java/Subtype.java
@@ -1,0 +1,10 @@
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+@Restricted(DoNotUse.class)
+public class Subtype extends Base<Integer> {
+  @Override
+  public Integer doStuff() {
+    return 42;
+  }
+}

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -237,6 +237,10 @@ public class Checker {
                 public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
                     this.className = name;
 
+                    if (isSynthetic(access)) {
+                        return;
+                    }
+
                     if (superName != null) {
                         for (Restrictions r : getRestrictions(superName)) {
                             r.usedAsSuperType(currentLocation, errorListener);
@@ -256,6 +260,11 @@ public class Checker {
                 public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                     this.methodName  = name;
                     this.methodDesc = desc;
+
+                    if (isSynthetic(access)) {
+                        return null;
+                    }
+
                     return new MethodVisitor(Opcodes.ASM5) {
                         @Override
                         public void visitLineNumber(int _line, Label start) {
@@ -374,4 +383,8 @@ public class Checker {
     }
 
     private static final String RESTRICTED_DESCRIPTOR = Type.getDescriptor(Restricted.class);
+
+    private static boolean isSynthetic(int access) {
+        return (access & Opcodes.ACC_SYNTHETIC) != 0;
+    }
 }


### PR DESCRIPTION
In certain cases the Java compiler generates code. This code is annotated as
being "synthetic".

Example:

When overriding a generic (abstract) method of a superclass like:

```
public abstract @Nonnull Collection<? extends Action> createFor(@Nonnull T target);
```

the following bytecode is generated (in *addition* to the normal method
definition):

```
// access flags 0x1041
public synthetic bridge createFor(Ljava/lang/Object;)Ljava/util/Collection;
 L0
  LINENUMBER 14 L0
  ALOAD 0
  ALOAD 1
  CHECKCAST hudson/model/Job
  INVOKEVIRTUAL org/jenkinsci/plugins/workflow/cps/Snippetizer$PerJobAdder.createFor (Lhudson/model/Job;)Ljava/util/Collection;
  ARETURN
 L1
  LOCALVARIABLE this Lorg/jenkinsci/plugins/workflow/cps/Snippetizer$PerJobAdder; L0 L1 0
  MAXSTACK = 2
  MAXLOCALS = 2
```

This is probably meant to support Java versions without generics.

Here the class `Snippetizer$PerJobAdder` is references in the bytecode.
This will lead to errors if this class is marked as `DoNotUse.class`.