### PR TITLE
Update annotation-indexer dependency

### DIFF
--- a/access-modifier-annotation/pom.xml
+++ b/access-modifier-annotation/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.4</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Fixes compilation for the Jenkins CLI module (which does not have an explicit annotation-indexer dependency) when compiling on Java 9 and up. The most relevant change is jenkinsci/lib-annotation-indexer#2 which adds Java 9 support.

CC @svanoort