### PR TITLE
[JENKINS-53675] Add the ability to disable checks for certain classes only

### DIFF
--- a/access-modifier-annotation/src/main/java/org/kohsuke/accmod/AccessRestriction.java
+++ b/access-modifier-annotation/src/main/java/org/kohsuke/accmod/AccessRestriction.java
@@ -38,7 +38,7 @@ import org.kohsuke.accmod.restrictions.None;
  * <p>
  * Single execution of the enforcement check would create at most one instance
  * of a given {@link AccessRestriction} type, so instance fields can be used to store
- * heavy-weight objects or other indicies that you might need for implementing
+ * heavy-weight objects or other indices that you might need for implementing
  * access control checks. 
  *
  * @author Kohsuke Kawaguchi

--- a/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/disable/DisableRestriction.java
+++ b/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/disable/DisableRestriction.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.kohsuke.accmod.restrictions.disable;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.jvnet.hudson.annotation_indexer.Indexed;
+import org.kohsuke.accmod.AccessRestriction;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicates that a particular element is really deprecated and that the access to it
+ * is subject to the additional restrictions.
+ *
+ * <p>
+ * These annotations and restrictions introduced by them are enforced by the
+ * "access-modifier-checker" mojo. 
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@Retention(RUNTIME)
+@Documented
+//@Indexed
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+public @interface DisableRestriction {
+    /**
+     * Kind of access that are restricted.
+     * If multiple values are specified, those restrictions are OR-ed &mdash; thus if an use
+     * violates any of the restrictions, it'll be considered as an error.
+     */
+    Class<?>[] value();
+}

--- a/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/disable/DisableRestriction.java
+++ b/access-modifier-annotation/src/main/java/org/kohsuke/accmod/restrictions/disable/DisableRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010, Kohsuke Kawaguchi
+ * Copyright (c) 2018, Steve Arch
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,28 +29,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import org.jvnet.hudson.annotation_indexer.Indexed;
 import org.kohsuke.accmod.AccessRestriction;
+import org.kohsuke.accmod.Restricted;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Indicates that a particular element is really deprecated and that the access to it
- * is subject to the additional restrictions.
+ * Indicates that certain classes annotated with {@link Restricted} annotations should be skipped during the
+ * access-modifier-check.
  *
- * <p>
- * These annotations and restrictions introduced by them are enforced by the
- * "access-modifier-checker" mojo. 
- *
- * @author Kohsuke Kawaguchi
+ * @author Steve Arch
  */
 @Retention(RUNTIME)
 @Documented
-//@Indexed
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
 public @interface DisableRestriction {
     /**
-     * Kind of access that are restricted.
-     * If multiple values are specified, those restrictions are OR-ed &mdash; thus if an use
-     * violates any of the restrictions, it'll be considered as an error.
+     * The classes that are marked as {@link Restricted} that should be skipped from the scan.
      */
     Class<?>[] value();
 }

--- a/access-modifier-checker/pom.xml
+++ b/access-modifier-checker/pom.xml
@@ -23,6 +23,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>access-modifier-suppressions</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-debug-all</artifactId>
     </dependency>

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>disable-restrictions-wrong-annotation</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>api</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/src/main/java/api/ApiWithRestrictedMethodAndField.java
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/src/main/java/api/ApiWithRestrictedMethodAndField.java
@@ -1,0 +1,13 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+public class ApiWithRestrictedMethodAndField {
+
+    @Restricted(NoExternalUse.class)
+    public String field;
+
+    @Restricted(NoExternalUse.class)
+    public static void notReallyPublic() {}
+}

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/src/main/java/api/RestrictedApi.java
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/src/main/java/api/RestrictedApi.java
@@ -1,0 +1,12 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class RestrictedApi {
+
+    public String field;
+
+    public void doNotUse() {}
+}

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/src/main/java/api/RestrictedInterface.java
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/api/src/main/java/api/RestrictedInterface.java
@@ -1,0 +1,8 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public interface RestrictedInterface {
+}

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>disable-restrictions-wrong-annotation</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>caller</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.kohsuke</groupId>
+                <artifactId>access-modifier-checker</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+           </plugin>
+        </plugins>
+    </build>
+</project>

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/Caller.java
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/Caller.java
@@ -1,0 +1,11 @@
+package caller;
+
+import api.ApiWithRestrictedMethodAndField;
+
+public class Caller {
+
+    @WrongAnnotation(ApiWithRestrictedMethodAndField.class)
+    public Caller() {
+        ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal
+    }
+}

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
@@ -1,0 +1,12 @@
+package caller;
+
+import api.ApiWithRestrictedMethodAndField;
+import api.RestrictedApi;
+import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+
+@WrongAnnotation(ApiWithRestrictedMethodAndField.class)
+public class CallerDisabledAtClassLevel {
+    public CallerDisabledAtClassLevel() {
+        ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal
+    }
+}

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
@@ -1,8 +1,6 @@
 package caller;
 
 import api.ApiWithRestrictedMethodAndField;
-import api.RestrictedApi;
-import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
 
 @WrongAnnotation(ApiWithRestrictedMethodAndField.class)
 public class CallerDisabledAtClassLevel {

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/WrongAnnotation.java
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/caller/src/main/java/caller/WrongAnnotation.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Steve Arch
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package caller;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Documented
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+public @interface WrongAnnotation {
+    Class<?>[] value();
+}

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/invoker.properties
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean package
+invoker.buildResult = failure

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>disable-restrictions-wrong-annotation</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+  <modules>
+    <module>api</module>
+    <module>caller</module>
+  </modules>
+</project>

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/postbuild.groovy
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/postbuild.groovy
@@ -1,0 +1,2 @@
+assert new File(basedir, 'build.log').text.contains('[ERROR] caller/Caller:9 api/ApiWithRestrictedMethodAndField.notReallyPublic()V must not be used')
+assert new File(basedir, 'build.log').text.contains('[ERROR] caller/CallerDisabledAtClassLevel:10 api/ApiWithRestrictedMethodAndField.notReallyPublic()V must not be used')

--- a/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/postbuild.groovy
+++ b/access-modifier-checker/src/it/disable-restrictions-wrong-annotation/postbuild.groovy
@@ -1,2 +1,2 @@
 assert new File(basedir, 'build.log').text.contains('[ERROR] caller/Caller:9 api/ApiWithRestrictedMethodAndField.notReallyPublic()V must not be used')
-assert new File(basedir, 'build.log').text.contains('[ERROR] caller/CallerDisabledAtClassLevel:10 api/ApiWithRestrictedMethodAndField.notReallyPublic()V must not be used')
+assert new File(basedir, 'build.log').text.contains('[ERROR] caller/CallerDisabledAtClassLevel:8 api/ApiWithRestrictedMethodAndField.notReallyPublic()V must not be used')

--- a/access-modifier-checker/src/it/disable-restrictions/api/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions/api/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>disable-restrictions</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>api</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/access-modifier-checker/src/it/disable-restrictions/api/src/main/java/api/ApiWithRestrictedMethodAndField.java
+++ b/access-modifier-checker/src/it/disable-restrictions/api/src/main/java/api/ApiWithRestrictedMethodAndField.java
@@ -1,0 +1,13 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+public class ApiWithRestrictedMethodAndField {
+
+    @Restricted(NoExternalUse.class)
+    public String field;
+
+    @Restricted(NoExternalUse.class)
+    public static void notReallyPublic() {}
+}

--- a/access-modifier-checker/src/it/disable-restrictions/api/src/main/java/api/RestrictedApi.java
+++ b/access-modifier-checker/src/it/disable-restrictions/api/src/main/java/api/RestrictedApi.java
@@ -1,0 +1,12 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class RestrictedApi {
+
+    public String field;
+
+    public void doNotUse() {}
+}

--- a/access-modifier-checker/src/it/disable-restrictions/api/src/main/java/api/RestrictedInterface.java
+++ b/access-modifier-checker/src/it/disable-restrictions/api/src/main/java/api/RestrictedInterface.java
@@ -1,0 +1,8 @@
+package api;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public interface RestrictedInterface {
+}

--- a/access-modifier-checker/src/it/disable-restrictions/caller/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/pom.xml
@@ -13,6 +13,11 @@
             <artifactId>api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-suppressions</artifactId>
+            <version>@project.version@</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/access-modifier-checker/src/it/disable-restrictions/caller/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>disable-restrictions</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>caller</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.kohsuke</groupId>
+                <artifactId>access-modifier-checker</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+           </plugin>
+        </plugins>
+    </build>
+</project>

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/Caller.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/Caller.java
@@ -1,0 +1,36 @@
+package caller;
+
+import api.ApiWithRestrictedMethodAndField;
+import api.RestrictedApi;
+import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+
+public class Caller extends ApiWithRestrictedMethodAndField { // This is fine, ApiWithRestrictedMethodAndField itself is not restricted
+
+    private RestrictedApi restrictedApi;
+
+    @DisableRestriction(ApiWithRestrictedMethodAndField.class)
+    public Caller() {
+        ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal but check disabled at the method level
+    }
+
+    @DisableRestriction({RestrictedApi.class, ApiWithRestrictedMethodAndField.class})
+    private void invalidFieldUse() {
+        restrictedApi.field = null;
+        super.field = null;
+    }
+
+    @DisableRestriction(ApiWithRestrictedMethodAndField.class)
+    public void callerMethod() {
+        ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal but check disabled at the method level
+    }
+
+    @DisableRestriction(RestrictedApi.class)
+    public void methodWithRestrictedParameter(RestrictedApi api) {
+        api.doNotUse(); // illegal but check disabled at the method level
+    }
+
+    @DisableRestriction(RestrictedApi.class)
+    public RestrictedApi getRestrictedApi() {
+        return new RestrictedApi(); // illegal but check disabled at the method level
+    }
+}

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/Caller.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/Caller.java
@@ -2,34 +2,34 @@ package caller;
 
 import api.ApiWithRestrictedMethodAndField;
 import api.RestrictedApi;
-import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
 public class Caller extends ApiWithRestrictedMethodAndField { // This is fine, ApiWithRestrictedMethodAndField itself is not restricted
 
     private RestrictedApi restrictedApi;
 
-    @DisableRestriction(ApiWithRestrictedMethodAndField.class)
+    @SuppressRestrictedWarnings(ApiWithRestrictedMethodAndField.class)
     public Caller() {
         ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal but check disabled at the method level
     }
 
-    @DisableRestriction({RestrictedApi.class, ApiWithRestrictedMethodAndField.class})
+    @SuppressRestrictedWarnings({RestrictedApi.class, ApiWithRestrictedMethodAndField.class})
     private void invalidFieldUse() {
         restrictedApi.field = null;
         super.field = null;
     }
 
-    @DisableRestriction(ApiWithRestrictedMethodAndField.class)
+    @SuppressRestrictedWarnings(ApiWithRestrictedMethodAndField.class)
     public void callerMethod() {
         ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal but check disabled at the method level
     }
 
-    @DisableRestriction(RestrictedApi.class)
+    @SuppressRestrictedWarnings(RestrictedApi.class)
     public void methodWithRestrictedParameter(RestrictedApi api) {
         api.doNotUse(); // illegal but check disabled at the method level
     }
 
-    @DisableRestriction(RestrictedApi.class)
+    @SuppressRestrictedWarnings(RestrictedApi.class)
     public RestrictedApi getRestrictedApi() {
         return new RestrictedApi(); // illegal but check disabled at the method level
     }

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
@@ -1,0 +1,32 @@
+package caller;
+
+import api.ApiWithRestrictedMethodAndField;
+import api.RestrictedApi;
+import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+
+@DisableRestriction( {ApiWithRestrictedMethodAndField.class, RestrictedApi.class})
+public class CallerDisabledAtClassLevel extends RestrictedApi {
+
+    private RestrictedApi restrictedApi;
+
+    public CallerDisabledAtClassLevel() {
+        ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal but check disabled at the class level
+    }
+
+    private void invalidFieldUse() {
+        restrictedApi.field = null;
+        super.field = null;
+    }
+
+    public void callerMethod() {
+        ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal but check disabled at the class level
+    }
+
+    public void methodWithRestrictedParameter(RestrictedApi api) {
+        api.doNotUse(); // illegal but check disabled at the class level
+    }
+
+    public RestrictedApi getRestrictedApi() {
+        return new RestrictedApi(); // illegal but check disabled at the class level
+    }
+}

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/CallerDisabledAtClassLevel.java
@@ -2,9 +2,9 @@ package caller;
 
 import api.ApiWithRestrictedMethodAndField;
 import api.RestrictedApi;
-import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
-@DisableRestriction( {ApiWithRestrictedMethodAndField.class, RestrictedApi.class})
+@SuppressRestrictedWarnings( {ApiWithRestrictedMethodAndField.class, RestrictedApi.class})
 public class CallerDisabledAtClassLevel extends RestrictedApi {
 
     private RestrictedApi restrictedApi;

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedApiSubclass.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedApiSubclass.java
@@ -1,0 +1,8 @@
+package caller;
+
+import api.RestrictedApi;
+import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+
+@DisableRestriction(RestrictedApi.class)
+public class RestrictedApiSubclass extends RestrictedApi {
+}

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedApiSubclass.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedApiSubclass.java
@@ -1,8 +1,8 @@
 package caller;
 
 import api.RestrictedApi;
-import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
-@DisableRestriction(RestrictedApi.class)
+@SuppressRestrictedWarnings(RestrictedApi.class)
 public class RestrictedApiSubclass extends RestrictedApi {
 }

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedInterfaceImplementation.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedInterfaceImplementation.java
@@ -1,8 +1,8 @@
 package caller;
 
 import api.RestrictedInterface;
-import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
-@DisableRestriction(RestrictedInterface.class)
+@SuppressRestrictedWarnings(RestrictedInterface.class)
 public class RestrictedInterfaceImplementation implements RestrictedInterface {
 }

--- a/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedInterfaceImplementation.java
+++ b/access-modifier-checker/src/it/disable-restrictions/caller/src/main/java/caller/RestrictedInterfaceImplementation.java
@@ -1,0 +1,8 @@
+package caller;
+
+import api.RestrictedInterface;
+import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+
+@DisableRestriction(RestrictedInterface.class)
+public class RestrictedInterfaceImplementation implements RestrictedInterface {
+}

--- a/access-modifier-checker/src/it/disable-restrictions/invoker.properties
+++ b/access-modifier-checker/src/it/disable-restrictions/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean package
+invoker.buildResult = success

--- a/access-modifier-checker/src/it/disable-restrictions/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>test</groupId>
-    <artifactId>no-external-use</artifactId>
+    <artifactId>disable-restrictions</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>

--- a/access-modifier-checker/src/it/disable-restrictions/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>no-external-use</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+    <modules>
+        <module>api</module>
+        <module>caller</module>
+    </modules>
+</project>

--- a/access-modifier-checker/src/it/disable-restrictions/pom.xml
+++ b/access-modifier-checker/src/it/disable-restrictions/pom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>test</groupId>
-    <artifactId>disable-restrictions</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-    </properties>
-    <modules>
-        <module>api</module>
-        <module>caller</module>
-    </modules>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>disable-restrictions</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+  <modules>
+    <module>api</module>
+    <module>caller</module>
+  </modules>
 </project>

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -29,6 +29,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.kohsuke.accmod.AccessRestriction;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.impl.Restrictions.Parser;
+import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -343,8 +344,9 @@ public class Checker {
 
         @Override
         public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-            return annotationVisitor;
-        }
+            return Type.getType(DisableRestriction.class).equals(Type.getType(desc))
+                    ? annotationVisitor
+                    : super.visitAnnotation(desc, visible);        }
 
         /**
          * Constant that represents the current location.
@@ -447,7 +449,9 @@ public class Checker {
 
         @Override
         public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-            return annotationVisitor;
+            return Type.getType(DisableRestriction.class).equals(Type.getType(desc))
+                    ? annotationVisitor
+                    : super.visitAnnotation(desc, visible);
         }
     }
 

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -29,7 +29,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.kohsuke.accmod.AccessRestriction;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.impl.Restrictions.Parser;
-import org.kohsuke.accmod.restrictions.disable.DisableRestriction;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -344,7 +344,7 @@ public class Checker {
 
         @Override
         public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-            return Type.getType(DisableRestriction.class).equals(Type.getType(desc))
+            return Type.getType(SuppressRestrictedWarnings.class).equals(Type.getType(desc))
                     ? annotationVisitor
                     : super.visitAnnotation(desc, visible);        }
 
@@ -449,7 +449,7 @@ public class Checker {
 
         @Override
         public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-            return Type.getType(DisableRestriction.class).equals(Type.getType(desc))
+            return Type.getType(SuppressRestrictedWarnings.class).equals(Type.getType(desc))
                     ? annotationVisitor
                     : super.visitAnnotation(desc, visible);
         }

--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/EnforcerMojo.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/EnforcerMojo.java
@@ -84,7 +84,7 @@ public class EnforcerMojo extends AbstractMojo {
                     public void onWarning(Throwable t, Location loc, String msg) {
                         getLog().warn(loc+" "+msg,t);
                     }
-                }, properties != null ? properties : new Properties());
+                }, properties != null ? properties : new Properties(), getLog());
 
             {// if there's restriction list in the inspected module itself, load it as well
                 InputStream self = null;

--- a/access-modifier-suppressions/pom.xml
+++ b/access-modifier-suppressions/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>access-modifier</artifactId>
+    <groupId>org.kohsuke</groupId>
+    <version>1.16-SNAPSHOT</version>
+  </parent>
+  <artifactId>access-modifier-suppressions</artifactId>
+
+  <name>Suppression for Access Modifier annotations</name>
+  <description>This module allows you to enable suppressions for turning off warnings about Restricted APIs.
+    !!!WARNING!!!
+    Classes are marked as @Restricted for a reason and this module should not be used lightly! It implies that the
+    author does not intend for them to be used outside their defined scope and as such they may be
+    changed/modified/removed at any stage without warning. A simple upgrade of the dependency may break your module. Use
+    at your own risk.
+    You should try to not use @Restricted classes in the first place, but if you _must_ use them, this is a less-brutal
+    approach than just disabling the access-modifier-checker entirely
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/access-modifier-suppressions/src/main/java/org/kohsuke/accmod/restrictions/suppressions/SuppressRestrictedWarnings.java
+++ b/access-modifier-suppressions/src/main/java/org/kohsuke/accmod/restrictions/suppressions/SuppressRestrictedWarnings.java
@@ -21,28 +21,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.kohsuke.accmod.restrictions.disable;
+package org.kohsuke.accmod.restrictions.suppressions;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import org.jvnet.hudson.annotation_indexer.Indexed;
-import org.kohsuke.accmod.AccessRestriction;
 import org.kohsuke.accmod.Restricted;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Indicates that certain classes annotated with {@link Restricted} annotations should be skipped during the
- * access-modifier-check.
+ * <p>Indicates that certain classes annotated with {@link Restricted} annotations should be skipped during the
+ * access-modifier-check.</p>
+ *
+ * <p><b>Warning!</b> Classes are markes as {@link Restricted} for a reason! Do not use these suppressions lightly.
+ * Use at your own risk</p>
  *
  * @author Steve Arch
  */
 @Retention(RUNTIME)
 @Documented
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
-public @interface DisableRestriction {
+public @interface SuppressRestrictedWarnings {
     /**
      * The classes that are marked as {@link Restricted} that should be skipped from the scan.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
   <modules>
     <module>access-modifier-annotation</module>
     <module>access-modifier-checker</module>
+    <module>access-modifier-suppressions</module>
   </modules>
 
   <distributionManagement>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-53675

Add an `@DisableRestriction` annotation that can be used at either the class or method level to disable `@Restricted` checks on a per-class basis.

Example use:
```
@DisableRestriction(RestrictedApi.class)
public class Caller extends ApiWithRestrictedMethodAndField { // This is fine, ApiWithRestrictedMethodAndField itself is not restricted

    private RestrictedApi restrictedApi;

    @DisableRestriction(ApiWithRestrictedMethodAndField.class)
    public Caller() {
        ApiWithRestrictedMethodAndField.notReallyPublic(); // illegal but check disabled at the method level
    }

    @DisableRestriction({RestrictedApi.class, ApiWithRestrictedMethodAndField.class}) // Duplicates class-level annotation, but included as an example.
    private void invalidFieldUse() {
        restrictedApi.field = null;
        super.field = null;
    }
```

For more use, see `it/disable-restrictions` integration test

@jenkinsci/code-reviewers @amuniz @jtnord