### PR TITLE
Make Checker constructor public

### DIFF
--- a/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
+++ b/access-modifier-checker/src/main/java/org/kohsuke/accmod/impl/Checker.java
@@ -93,7 +93,7 @@ public class Checker {
 
     private int line;
 
-    Checker(ClassLoader dependencies, ErrorListener errorListener, Properties properties,
+    public Checker(ClassLoader dependencies, ErrorListener errorListener, Properties properties,
             Log log) throws IOException {
         this.dependencies = dependencies;
         this.errorListener = errorListener;


### PR DESCRIPTION
Enables use from outside the package. See jenkinsci/gradle-jpi-plugin#162 for an example use-case.